### PR TITLE
fix: changed the link in navigate to /issues instead of /errors

### DIFF
--- a/src/errors/components/Sidebar.tsx
+++ b/src/errors/components/Sidebar.tsx
@@ -17,7 +17,7 @@ export default function Sidebar() {
 
   const handleClick = (project: Project) => {
     selectProject(project.uuid);
-    navigate(`/projects/${project.uuid}/errors`);
+    navigate(`/projects/${project.uuid}/issues`);
   };
 
   return (


### PR DESCRIPTION
The handleClick method in sidebar was still directing to the old route, I changed it to end in /issues instead of /errors.