### PR TITLE
fix: call checkSession on all routes to stay logged in

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -48,12 +48,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setIsLoggedIn(false);
       }
     };
-    if (
-      window.location.pathname !== "/" &&
-      window.location.pathname !== "/login"
-    ) {
-      checkSession();
-    }
+
+    checkSession();
   }, []);
 
   const login = (


### PR DESCRIPTION
The conditional in `AuthContext` was limited to check the session if the user visited "/" or "/login". This prevented the user from staying logged in if they refresh the page, or the components re-render, on any other route. I removed the conditional so the user will stay logged in on every route, to improve UX.