### PR TITLE
feat: interpolate project api keys in set up instructions

### DIFF
--- a/src/projects/components/FlaskSetup.tsx
+++ b/src/projects/components/FlaskSetup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import {
   Box,
   Heading,
@@ -10,10 +10,24 @@ import {
 } from "@chakra-ui/react";
 import { useParams, useNavigate } from "react-router-dom";
 import CodeDisplay from "./CodeDisplay";
+import { useProjects } from "../../hooks/useProjects";
 
-const FlaskSetup: React.FC = () => {
+const FlaskSetup: React.FC<{apiKey: string}> = ({ apiKey }) => {
+  const { projects } = useProjects();
   const { project_uuid } = useParams();
   const navigate = useNavigate();
+  const [currentApiKey, setCurrentApiKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (apiKey) {
+      setCurrentApiKey(apiKey);
+    } else if (project_uuid) {
+      const project = projects.find((p) => p.uuid === project_uuid);
+      if (project) {
+        setCurrentApiKey(project.api_key);
+      }
+    }
+  }, [apiKey, project_uuid, projects]);
 
   const handleButtonClick = () => {
     if (project_uuid) {
@@ -51,7 +65,7 @@ const FlaskSetup: React.FC = () => {
             </Text>
             <CodeDisplay
               language="python"
-              code={`from flytrap import Flytrap`}
+              code={`import flytrap`}
             />
           </Box>
 
@@ -66,9 +80,9 @@ const FlaskSetup: React.FC = () => {
             </Text>
             <CodeDisplay
               language="python"
-              code={`error_monitor = Flytrap({
+              code={`flytrap.init({
     api_endpoint: ${import.meta.env.VITE_FLYTRAP_SDK_URL},
-    api_key: ${"WILL_BE_SENT_FROM_BACKEND"},
+    api_key: ${currentApiKey},
     project_id: ${project_uuid}'
   })`}
             />
@@ -85,7 +99,7 @@ const FlaskSetup: React.FC = () => {
             </Text>
             <CodeDisplay
               language="python"
-              code={`flytrap.setup_flask_error_handler()`}
+              code={`flytrap.setup_flask_error_handler(app)`}
             />
             <Text mt={4} fontSize="md">
               Now, all unhandled exceptions that occur while your app is running
@@ -104,8 +118,8 @@ const FlaskSetup: React.FC = () => {
             <CodeDisplay
               language="python"
               code={`try:
-      # Some code that might raise an exception
-  except Exception as e:
+    # Some code that might raise an exception
+except Exception as e:
       flytrap.capture_exception(e)`}
             />
           </Box>

--- a/src/projects/components/JavaScriptSetup.tsx
+++ b/src/projects/components/JavaScriptSetup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import {
   Box,
   Heading,
@@ -10,10 +10,24 @@ import {
 } from "@chakra-ui/react";
 import { useParams, useNavigate } from "react-router-dom";
 import CodeDisplay from "./CodeDisplay";
+import { useProjects } from "../../hooks/useProjects";
 
-const JavaScriptSetup: React.FC = () => {
+const JavaScriptSetup: React.FC<{apiKey: string}> = ({ apiKey }) => {
+  const { projects } = useProjects(); 
   const { project_uuid } = useParams();
   const navigate = useNavigate();
+  const [currentApiKey, setCurrentApiKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (apiKey) {
+      setCurrentApiKey(apiKey);
+    } else if (project_uuid) {
+      const project = projects.find((p) => p.uuid === project_uuid);
+      if (project) {
+        setCurrentApiKey(project.api_key);
+      }
+    }
+  }, [apiKey, project_uuid, projects]);
 
   const handleButtonClick = () => {
     if (project_uuid) {
@@ -43,12 +57,6 @@ const JavaScriptSetup: React.FC = () => {
             <Text mb={4}>
               To use Flytrap, simply include the SDK in your project.
             </Text>
-            <Divider />
-            <br />
-
-            <Text fontSize="lg" mb={2} fontWeight="bold">
-              Via Script Tag:
-            </Text>
             <Text mb={4}>
               The SDK is distributed in UMD format, allowing it to be imported
               directly in the browser with a <Code>&lt;script&gt;</Code> tag:
@@ -57,18 +65,6 @@ const JavaScriptSetup: React.FC = () => {
               language="html"
               code={`<script src="scripts/flytrap/index.js"></script>`}
             />
-            <Divider />
-            <br />
-
-            <Text fontSize="lg" mt={4} fontWeight="bold">
-              Development:
-            </Text>
-            <Text mt={4}>
-              Run <Code>npm build</Code> to create the bundled version. Then,
-              copy the bundled <Code>dist/index.debug.js</Code> and{" "}
-              <Code>index.debug.js.map</Code> file into a{" "}
-              <Code>scripts/flytrap</Code> directory.
-            </Text>
           </Box>
 
           <Divider />
@@ -85,10 +81,10 @@ const JavaScriptSetup: React.FC = () => {
             </Text>
             <CodeDisplay
               language="javascript"
-              code={`const flytrap = new Flytrap({
+              code={`flytrap.init({
     projectId: ${project_uuid},
     apiEndpoint: ${import.meta.env.VITE_FLYTRAP_SDK_URL},
-    apiKey: ${"WILL_BE_SENT_FROM_BACKEND"}
+    apiKey: ${currentApiKey}
   });`}
             />
           </Box>

--- a/src/projects/components/ProjectModals.tsx
+++ b/src/projects/components/ProjectModals.tsx
@@ -86,6 +86,7 @@ const ProjectModals = ({
           name: data.name,
           issue_count: 0,
           platform: data.platform,
+          api_key: data.api_key
         },
       ]);
       onNewProjectClose();
@@ -99,7 +100,7 @@ const ProjectModals = ({
         isClosable: true,
       });
       navigate(`/projects/${data.uuid}/setup`, {
-        state: { platform: selectedPlatform },
+        state: { platform: selectedPlatform, apiKey: data.api_key },
       });
     } catch {
       toast({

--- a/src/projects/components/ReactSetup.tsx
+++ b/src/projects/components/ReactSetup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import {
   Box,
   Heading,
@@ -9,10 +9,24 @@ import {
 } from "@chakra-ui/react";
 import { useParams, useNavigate } from "react-router-dom";
 import CodeDisplay from "./CodeDisplay";
+import { useProjects } from "../../hooks/useProjects";
 
-const ReactSetup: React.FC = () => {
+const ReactSetup: React.FC<{apiKey: string}> = ({ apiKey }) => {
+  const { projects } = useProjects();
   const { project_uuid } = useParams();
   const navigate = useNavigate();
+  const [currentApiKey, setCurrentApiKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (apiKey) {
+      setCurrentApiKey(apiKey);
+    } else if (project_uuid) {
+      const project = projects.find((p) => p.uuid === project_uuid);
+      if (project) {
+        setCurrentApiKey(project.api_key);
+      }
+    }
+  }, [apiKey, project_uuid, projects]);
 
   const handleButtonClick = () => {
     if (project_uuid) {
@@ -57,13 +71,13 @@ const ReactSetup: React.FC = () => {
 
           <CodeDisplay
             language="typescript"
-            code={`import Flytrap from "flytrap_react";
+            code={`import flytrap from "flytrap_react";
   
   // Initialize Flytrap with your project credentials
-  const flytrap = new Flytrap({
+  flytrap.init({
     projectId: ${project_uuid},
     apiEndpoint: ${import.meta.env.VITE_FLYTRAP_SDK_URL},
-    apiKey: ${"WILL_BE_SENT_FROM_BACKEND"}
+    apiKey: ${currentApiKey}
   });`}
           />
 
@@ -75,7 +89,7 @@ const ReactSetup: React.FC = () => {
           <CodeDisplay
             language="tsx"
             code={`createRoot(document.getElementById("root")!).render(
-    <Flytrap.ErrorBoundary flytrap={flytrap}>
+    <Flytrap.ErrorBoundary>
       <App />
     </Flytrap.ErrorBoundary>
   );

--- a/src/projects/pages/ProjectSetup.tsx
+++ b/src/projects/pages/ProjectSetup.tsx
@@ -8,23 +8,22 @@ import ExpressSetup from "../components/ExpressSetup";
 
 const ProjectSetup: React.FC = () => {
   const location = useLocation();
-  const { platform } = location.state || {};
-  console.log("in ProjectSetup", platform);
+  const { platform, apiKey } = location.state || {};
 
   let platformComponent: React.ReactNode;
 
   switch (platform) {
     case "React":
-      platformComponent = <ReactSetup />;
+      platformComponent = <ReactSetup apiKey={apiKey}/>;
       break;
     case "JavaScript":
-      platformComponent = <JavaScriptSetup />;
+      platformComponent = <JavaScriptSetup apiKey={apiKey}/>;
       break;
     case "Flask":
-      platformComponent = <FlaskSetup />;
+      platformComponent = <FlaskSetup apiKey={apiKey}/>;
       break;
     case "Express.js":
-      platformComponent = <ExpressSetup />;
+      platformComponent = <ExpressSetup apiKey={apiKey}/>;
       break;
     default:
       platformComponent = <Text>No platform selected</Text>;

--- a/src/services/projects/projectsTypes.ts
+++ b/src/services/projects/projectsTypes.ts
@@ -11,9 +11,11 @@ export interface getAllProjectsResponse {
 }
 
 export interface createProjectResponse {
+  status: string;
   data: {
     uuid: string;
     name: string;
     platform: string;
+    api_key: string;
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export interface Project {
   name: string;
   issue_count: number;
   platform: string;
+  api_key: string;
 }
 
 export interface User {


### PR DESCRIPTION
Interpolated the api key into the setup instructions on project creation, and fetch project api key from state if the setup instructions are revisited.