### PR TITLE
fix: resolve invalid project message on valid project refresh

### DIFF
--- a/src/errors/pages/ErrorDisplay.tsx
+++ b/src/errors/pages/ErrorDisplay.tsx
@@ -56,7 +56,7 @@ const ErrorDisplay = () => {
       }
     };
 
-    if (!selectedProject || projects.length === 0) loadProject();
+    loadProject();
   }, [
     projects,
     projectUuid,

--- a/src/projects/components/JavaScriptSetup.tsx
+++ b/src/projects/components/JavaScriptSetup.tsx
@@ -63,7 +63,7 @@ const JavaScriptSetup: React.FC<{ apiKey: string }> = ({ apiKey }) => {
           <CodeDisplay
             language="html"
             code={
-              "<script src='https://cdn.flytrap.com/sdk/flytrap.js'></script>"
+              "<script src='https://cdn.jsdelivr.net/npm/flytrap_javascript/dist/index.js'></script>"
             }
           />
 


### PR DESCRIPTION
Fixes issue where valid projects were marked as invalid on page refresh. Ensures `loadProject` runs consistently by removing the conditional check and validating the project after `fetchProjectsForUser` completes. Prevents premature state updates and improves reliability of project validation.
